### PR TITLE
Network resolf.conf handling (#220)

### DIFF
--- a/linux/network/init.sls
+++ b/linux/network/init.sls
@@ -6,9 +6,6 @@ include:
 {%- if network.host|length > 0 or network.get('purge_hosts', True) %}
 - linux.network.host
 {%- endif %}
-{%- if network.resolv is defined %}
-- linux.network.resolv
-{%- endif %}
 {%- if network.dpdk is defined %}
 - linux.network.dpdk
 {%- endif %}
@@ -23,5 +20,8 @@ include:
 {%- endif %}
 {%- if network.interface|length > 0 %}
 - linux.network.interface
+{%- endif %}
+{%- if network.resolv is defined %}
+- linux.network.resolv
 {%- endif %}
 - linux.network.proxy

--- a/linux/network/interface.sls
+++ b/linux/network/interface.sls
@@ -173,7 +173,7 @@ ovs_bond_{{ interface_name }}:
   cmd.run:
     - name: ovs-vsctl add-bond {{ interface.bridge }} {{ interface_name }} {{ interface.slaves }} bond_mode={{ interface.mode }}
     - unless: ovs-vsctl show | grep -A 2 'Port.*{{ interface_name }}.'
-    - require: 
+    - require:
       - ovs_bridge_{{ interface.bridge }}_present
 
 {%- elif interface.type == 'ovs_port' %}
@@ -349,7 +349,7 @@ remove_interface_{{ network }}_line2:
 
 {%- endfor %}
 
-{%- if interface.gateway is defined %}
+{%- if interface.gateway is defined and network.resolv is not defined %}
 
 linux_system_network:
   network.system:


### PR DESCRIPTION
* Update file.sls

add replace

* Update file.sls

update replace

* Update job.sls

Added the opportunity to set a job with a special keyword like '@reboot' or '@hourly'. Quotes must be used, otherwise PyYAML will strip the '@' sign.
https://docs.saltstack.com/en/master/ref/states/all/salt.states.cron.html

* Update README.rst

Added the opportunity to set a job with a special keyword like '@reboot' or '@hourly'. Quotes must be used, otherwise PyYAML will strip the '@' sign.

* Update README.rst

* fix(deprecation): update to new method (#214)

Signed-off-by: Felipe Zipitria <fzipitria@perceptyx.com>

* Allow swap to be completely disabled

* sort repos so they do not change order every run

* allow use of new state syntax for module.run

The new syntax has been supported since ~2017.
From the docs, in case they change:

! New Style
test.random_hash:
  module.run:
    - test.random_hash:
      - size: 42
      - hash_type: sha256

! Legacy Style
test.random_hash:
  module.run:
    - size: 42
    - hash_type: sha256

* Update map.jinja

Add support fpr Ubuntu Focal.

* Update file.sls

added possibility to delete files

* Network resolf.conf handling

the handling as the Resolv.conf is generated and adapted, adapted.
previously the Resolv.conf was created and then through
Overwrite "network.system" in the interface.sls again.
With two search servers that should actually be included.
"search example.com. sudomain.example.com"
but it always became that
search ['example.com.', 'sudomain.example.com']

The resolv.conf was first created correctly but then overwritten again in the interface.sls.

The problem only arises if you don't want to have a "Domain:" in resov.conf

Co-authored-by: Felipe Zipitría <fzipi@fing.edu.uy>
Co-authored-by: Kyle Gullion <kgullion@gmail.com>
Co-authored-by: Matthew Thode <thode@fsi.io>
Co-authored-by: Matthew Thode <mthode@mthode.org>