### PR TITLE
Fix warning in salt v3003

### DIFF
--- a/linux/system/user.sls
+++ b/linux/system/user.sls
@@ -49,7 +49,7 @@ system_user_{{ name }}:
   {%- if user.gid is defined and user.gid %}
   - gid: {{ user.gid }}
   {%- else %}
-  - gid_from_name: true
+  - gid: {{ name }}
   {%- endif %}
   {%- if user.groups is defined %}
   - groups: {{ user.groups }}


### PR DESCRIPTION
The 'gid_from_name' argument in the user.present state has been replaced with 'usergroup'. Update your SLS file to get rid of this warning.